### PR TITLE
Sdc populate new

### DIFF
--- a/app/aidbox/operations.py
+++ b/app/aidbox/operations.py
@@ -12,11 +12,13 @@ from ..sdc import (
     resolve_expression,
 )
 from ..sdc.exception import MissingParamOperationOutcome
-from ..sdc.utils import parameter_to_env, validate_context
+from ..sdc.utils import parameter_to_env, parse_parameter_value, validate_context
 from ..utils import get_extract_services
 from .settings import settings
 from .utils import AidboxSdcRequest, aidbox_operation, get_user_sdk_client, prepare_args
 
+# TODO: it's outside from spec, if it's only for data fetching,
+# TODO: better to use dataEndpoint and it should be handled in `parameter_to_env` function
 EXTERNAL_FHIR_BASE_URL_PARAM_KEY = "externalFhirBaseUrl"
 
 
@@ -47,15 +49,17 @@ async def assemble_op(request: AidboxSdcRequest):
 @aidbox_operation(["POST"], ["QuestionnaireResponse", "$constraint-check"])
 @prepare_args
 async def constraint_check_operation(request: AidboxSdcRequest):
-    env = parameter_to_env(request.resource, request.is_fhir)
+    client = get_user_sdk_client(
+        request.request,
+        request.client,
+        _get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
+    )
+    env = await parameter_to_env(client, request.resource, request.is_fhir)
 
     fce_questionnaire = (
         await to_first_class_extension(env["Questionnaire"], request.aidbox_client)
         if request.is_fhir
         else env["Questionnaire"]
-    )
-    client = get_user_sdk_client(
-        request.request, request.client, env.get(EXTERNAL_FHIR_BASE_URL_PARAM_KEY)
     )
 
     return web.json_response(
@@ -72,15 +76,17 @@ async def constraint_check_operation(request: AidboxSdcRequest):
 @aidbox_operation(["POST"], ["Questionnaire", "$context"])
 @prepare_args
 async def get_questionnaire_context_operation(request: AidboxSdcRequest):
-    env = parameter_to_env(request.resource, request.is_fhir)
+    client = get_user_sdk_client(
+        request.request,
+        request.client,
+        _get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
+    )
+    env = await parameter_to_env(client, request.resource, request.is_fhir)
 
     fce_questionnaire = (
         await to_first_class_extension(env["Questionnaire"], request.aidbox_client)
         if request.is_fhir
         else env["Questionnaire"]
-    )
-    client = get_user_sdk_client(
-        request.request, request.client, env.get(EXTERNAL_FHIR_BASE_URL_PARAM_KEY)
     )
     result = await get_questionnaire_context(client, fce_questionnaire, env)
 
@@ -91,6 +97,11 @@ async def get_questionnaire_context_operation(request: AidboxSdcRequest):
 @prepare_args
 async def extract_questionnaire_operation(request: AidboxSdcRequest):
     resource = request.resource
+    client = get_user_sdk_client(
+        request.request,
+        request.client,
+        _get_external_fhir_base_url_from_resource(resource, request.is_fhir),
+    )
     if resource["resourceType"] == "QuestionnaireResponse":
         env = {}
         env_questionnaire_response = resource
@@ -104,7 +115,7 @@ async def extract_questionnaire_operation(request: AidboxSdcRequest):
         )
         env_questionnaire = fhir_questionnaire if request.is_fhir else fce_questionnaire
     elif resource["resourceType"] == "Parameters":
-        env = parameter_to_env(request.resource, request.is_fhir)
+        env = await parameter_to_env(client, resource, request.is_fhir)
         if "Questionnaire" not in env:
             raise MissingParamOperationOutcome("`Questionnaire` parameter is required")
         if "QuestionnaireResponse" not in env:
@@ -129,9 +140,6 @@ async def extract_questionnaire_operation(request: AidboxSdcRequest):
         **env,
     }
 
-    client = get_user_sdk_client(
-        request.request, request.client, env.get(EXTERNAL_FHIR_BASE_URL_PARAM_KEY)
-    )
     await constraint_check(
         client,
         fce_questionnaire,
@@ -148,6 +156,11 @@ async def extract_questionnaire_operation(request: AidboxSdcRequest):
 @prepare_args
 async def extract_questionnaire_instance_operation(request: AidboxSdcRequest):
     resource = request.resource
+    extract_client = get_user_sdk_client(
+        request.request,
+        request.client,
+        _get_external_fhir_base_url_from_resource(resource, request.is_fhir),
+    )
     fhir_questionnaire = (
         await request.fhir_client.resources("Questionnaire")
         .search(_id=request.route_params["id"])
@@ -155,7 +168,7 @@ async def extract_questionnaire_instance_operation(request: AidboxSdcRequest):
     )
     fce_questionnaire = await to_first_class_extension(fhir_questionnaire, request.aidbox_client)
     env_questionnaire = fhir_questionnaire if request.is_fhir else fce_questionnaire
-    extract_client = get_user_sdk_client(request.request, request.client)
+
     return web.json_response(
         await extract_questionnaire_instance(
             request.aidbox_client,
@@ -183,7 +196,7 @@ async def extract_questionnaire_instance(
         env = {}
         env_questionnaire_response = extract_client.resource("QuestionnaireResponse", **resource)
     elif resource["resourceType"] == "Parameters":
-        env = parameter_to_env(resource, is_fhir)
+        env = await parameter_to_env(extract_client, resource, is_fhir)
         if "QuestionnaireResponse" not in env:
             raise MissingParamOperationOutcome("`QuestionnaireResponse` parameter is required")
 
@@ -217,14 +230,15 @@ async def extract_questionnaire_instance(
 @aidbox_operation(["POST"], ["Questionnaire", "$populate"])
 @prepare_args
 async def populate_questionnaire(request: AidboxSdcRequest):
-    env = parameter_to_env(request.resource, request.is_fhir)
+    client = get_user_sdk_client(
+        request.request,
+        request.client,
+        _get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
+    )
+    env = await parameter_to_env(client, request.resource, request.is_fhir)
 
     if "Questionnaire" not in env:
         raise MissingParamOperationOutcome("`Questionnaire` parameter is required")
-
-    client = get_user_sdk_client(
-        request.request, request.client, env.get(EXTERNAL_FHIR_BASE_URL_PARAM_KEY)
-    )
 
     populated_qr = await populate(client, env["Questionnaire"], env)
     return web.json_response(populated_qr, dumps=json.dumps)
@@ -233,16 +247,19 @@ async def populate_questionnaire(request: AidboxSdcRequest):
 @aidbox_operation(["POST"], ["Questionnaire", {"name": "id"}, "$populate"])
 @prepare_args
 async def populate_questionnaire_instance(request: AidboxSdcRequest):
+    client = get_user_sdk_client(
+        request.request,
+        request.client,
+        _get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
+    )
     fhir_questionnaire = (
         await request.fhir_client.resources("Questionnaire")
         .search(_id=request.route_params["id"])
         .get()
     )
-    env = parameter_to_env(request.resource, request.is_fhir)
+
+    env = await parameter_to_env(client, request.resource, request.is_fhir)
     env["Questionnaire"] = fhir_questionnaire
-    client = get_user_sdk_client(
-        request.request, request.client, env.get(EXTERNAL_FHIR_BASE_URL_PARAM_KEY)
-    )
 
     populated_qr = await populate(client, env["Questionnaire"], env)
 
@@ -252,3 +269,16 @@ async def populate_questionnaire_instance(request: AidboxSdcRequest):
 @aidbox_operation(["POST"], ["Questionnaire", "$resolve-expression"], public=True)
 def resolve_expression_operation(_operation, request):
     return web.json_response(resolve_expression(request["resource"]), dumps=json.dumps)
+
+
+def _get_external_fhir_base_url_from_resource(resource: dict | None, is_fhir: bool):
+    if not resource or resource.get("resourceType") != "Parameters":
+        return None
+    for param in resource.get("parameter", []):
+        if param.get("name") != EXTERNAL_FHIR_BASE_URL_PARAM_KEY:
+            continue
+        if "resource" in param:
+            continue
+        value = parse_parameter_value(param, is_fhir)
+        return value or None
+    return None

--- a/app/aidbox/operations.py
+++ b/app/aidbox/operations.py
@@ -12,7 +12,12 @@ from ..sdc import (
     resolve_expression,
 )
 from ..sdc.exception import MissingParamOperationOutcome
-from ..sdc.utils import get_external_fhir_base_url_from_resource, parameter_to_env, validate_context
+from ..sdc.utils import (
+    get_external_fhir_base_url_from_resource,
+    is_sdc_api,
+    parameter_to_env,
+    validate_context,
+)
 from ..utils import get_extract_services
 from .settings import settings
 from .utils import AidboxSdcRequest, aidbox_operation, get_user_sdk_client, prepare_args
@@ -236,7 +241,9 @@ async def populate_questionnaire(request: AidboxSdcRequest):
     if "Questionnaire" not in env:
         raise MissingParamOperationOutcome("`Questionnaire` parameter is required")
 
-    populated_qr = await populate(client, env["Questionnaire"], env)
+    populated_qr = await populate(
+        client, env["Questionnaire"], env, sdc_api=is_sdc_api(request.resource)
+    )
     return web.json_response(populated_qr, dumps=json.dumps)
 
 
@@ -257,7 +264,9 @@ async def populate_questionnaire_instance(request: AidboxSdcRequest):
     env = await parameter_to_env(client, request.resource, request.is_fhir)
     env["Questionnaire"] = fhir_questionnaire
 
-    populated_qr = await populate(client, env["Questionnaire"], env)
+    populated_qr = await populate(
+        client, env["Questionnaire"], env, sdc_api=is_sdc_api(request.resource)
+    )
 
     return web.json_response(populated_qr, dumps=json.dumps)
 

--- a/app/aidbox/operations.py
+++ b/app/aidbox/operations.py
@@ -12,14 +12,10 @@ from ..sdc import (
     resolve_expression,
 )
 from ..sdc.exception import MissingParamOperationOutcome
-from ..sdc.utils import parameter_to_env, parse_parameter_value, validate_context
+from ..sdc.utils import get_external_fhir_base_url_from_resource, parameter_to_env, validate_context
 from ..utils import get_extract_services
 from .settings import settings
 from .utils import AidboxSdcRequest, aidbox_operation, get_user_sdk_client, prepare_args
-
-# TODO: it's outside from spec, if it's only for data fetching,
-# TODO: better to use dataEndpoint and it should be handled in `parameter_to_env` function
-EXTERNAL_FHIR_BASE_URL_PARAM_KEY = "externalFhirBaseUrl"
 
 
 @aidbox_operation(["GET"], ["Questionnaire", {"name": "id"}, "$assemble"])
@@ -52,7 +48,7 @@ async def constraint_check_operation(request: AidboxSdcRequest):
     client = get_user_sdk_client(
         request.request,
         request.client,
-        _get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
+        get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
     )
     env = await parameter_to_env(client, request.resource, request.is_fhir)
 
@@ -79,7 +75,7 @@ async def get_questionnaire_context_operation(request: AidboxSdcRequest):
     client = get_user_sdk_client(
         request.request,
         request.client,
-        _get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
+        get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
     )
     env = await parameter_to_env(client, request.resource, request.is_fhir)
 
@@ -100,7 +96,7 @@ async def extract_questionnaire_operation(request: AidboxSdcRequest):
     client = get_user_sdk_client(
         request.request,
         request.client,
-        _get_external_fhir_base_url_from_resource(resource, request.is_fhir),
+        get_external_fhir_base_url_from_resource(resource, request.is_fhir),
     )
     if resource["resourceType"] == "QuestionnaireResponse":
         env = {}
@@ -159,7 +155,7 @@ async def extract_questionnaire_instance_operation(request: AidboxSdcRequest):
     extract_client = get_user_sdk_client(
         request.request,
         request.client,
-        _get_external_fhir_base_url_from_resource(resource, request.is_fhir),
+        get_external_fhir_base_url_from_resource(resource, request.is_fhir),
     )
     fhir_questionnaire = (
         await request.fhir_client.resources("Questionnaire")
@@ -233,7 +229,7 @@ async def populate_questionnaire(request: AidboxSdcRequest):
     client = get_user_sdk_client(
         request.request,
         request.client,
-        _get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
+        get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
     )
     env = await parameter_to_env(client, request.resource, request.is_fhir)
 
@@ -250,7 +246,7 @@ async def populate_questionnaire_instance(request: AidboxSdcRequest):
     client = get_user_sdk_client(
         request.request,
         request.client,
-        _get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
+        get_external_fhir_base_url_from_resource(request.resource, request.is_fhir),
     )
     fhir_questionnaire = (
         await request.fhir_client.resources("Questionnaire")
@@ -269,16 +265,3 @@ async def populate_questionnaire_instance(request: AidboxSdcRequest):
 @aidbox_operation(["POST"], ["Questionnaire", "$resolve-expression"], public=True)
 def resolve_expression_operation(_operation, request):
     return web.json_response(resolve_expression(request["resource"]), dumps=json.dumps)
-
-
-def _get_external_fhir_base_url_from_resource(resource: dict | None, is_fhir: bool):
-    if not resource or resource.get("resourceType") != "Parameters":
-        return None
-    for param in resource.get("parameter", []):
-        if param.get("name") != EXTERNAL_FHIR_BASE_URL_PARAM_KEY:
-            continue
-        if "resource" in param:
-            continue
-        value = parse_parameter_value(param, is_fhir)
-        return value or None
-    return None

--- a/app/fhir_server/operations.py
+++ b/app/fhir_server/operations.py
@@ -43,20 +43,19 @@ async def assemble_handler(request: web.BaseRequest):
 
 @routes.post("/QuestionnaireResponse/$constraint-check")
 async def constraint_check_handler(request: web.BaseRequest):
-    env = parameter_to_env(await request.json())
+    client = request.app["client"]
+    env = await parameter_to_env(client, await request.json())
     # TODO: I believe there's a bug, it should be in FHIR format
     env["Questionnaire"] = to_first_class_extension(env["Questionnaire"])
     env["QuestionnaireResponse"] = to_first_class_extension(env["QuestionnaireResponse"])
-    client = request.app["client"]
 
     return web.json_response(await constraint_check(client, env["Questionnaire"], env))
 
 
 @routes.post("/Questionnaire/$context")
 async def get_questionnaire_context_handler(request: web.BaseRequest):
-    client = request["app"]["client"]
-    env = parameter_to_env(await request.json())
     client = request.app["client"]
+    env = await parameter_to_env(client, await request.json())
 
     return web.json_response(
         await get_questionnaire_context(client, to_first_class_extension(env["Questionnaire"]), env)
@@ -75,7 +74,7 @@ async def extract_questionnaire_handler(request: web.BaseRequest):
             await client.resources("Questionnaire").search(_id=resource["questionnaire"]).get()
         )
     elif resource["resourceType"] == "Parameters":
-        env = parameter_to_env(resource)
+        env = await parameter_to_env(client, resource)
         # TODO: Use FHIR spec questionnaire
         questionnaire = env.get("Questionnaire")
         questionnaire_response = env.get("QuestionnaireResponse")
@@ -163,7 +162,7 @@ async def extract_questionnaire_instance_operation(request: web.BaseRequest):
         )
 
     if resource["resourceType"] == "Parameters":
-        env = parameter_to_env(resource)
+        env = await parameter_to_env(client, resource)
 
         questionnaire_response_data = env.get("QuestionnaireResponse")
         if not questionnaire_response_data:
@@ -207,7 +206,7 @@ async def extract_questionnaire_instance_operation(request: web.BaseRequest):
 @routes.post("/Questionnaire/$populate")
 async def populate_questionnaire_handler(request: web.BaseRequest):
     client = request.app["client"]
-    env = parameter_to_env(await request.json())
+    env = await parameter_to_env(client, await request.json())
     questionnaire_data = env["Questionnaire"]
     if not questionnaire_data:
         # TODO: return OperationOutcome
@@ -229,7 +228,7 @@ async def populate_questionnaire_instance(request: web.BaseRequest):
     questionnaire = (
         await client.resources("Questionnaire").search(_id=request.match_info["id"]).get()
     )
-    env = parameter_to_env(request["resource"])
+    env = await parameter_to_env(client, request["resource"])
     env["Questionnaire"] = questionnaire
     populated_resource = await populate(client, questionnaire, env)
 

--- a/app/fhir_server/operations.py
+++ b/app/fhir_server/operations.py
@@ -15,7 +15,7 @@ from ..sdc import (
     populate,
     resolve_expression,
 )
-from ..sdc.utils import parameter_to_env, validate_context
+from ..sdc.utils import is_sdc_api, parameter_to_env, validate_context
 from ..utils import get_extract_services
 
 routes = web.RouteTableDef()
@@ -206,7 +206,8 @@ async def extract_questionnaire_instance_operation(request: web.BaseRequest):
 @routes.post("/Questionnaire/$populate")
 async def populate_questionnaire_handler(request: web.BaseRequest):
     client = request.app["client"]
-    env = await parameter_to_env(client, await request.json())
+    body = await request.json()
+    env = await parameter_to_env(client, body)
     questionnaire_data = env["Questionnaire"]
     if not questionnaire_data:
         # TODO: return OperationOutcome
@@ -218,7 +219,7 @@ async def populate_questionnaire_handler(request: web.BaseRequest):
             status=422,
         )
 
-    populated_resource = await populate(client, questionnaire_data, env)
+    populated_resource = await populate(client, questionnaire_data, env, sdc_api=is_sdc_api(body))
     return web.json_response(populated_resource)
 
 
@@ -228,9 +229,10 @@ async def populate_questionnaire_instance(request: web.BaseRequest):
     questionnaire = (
         await client.resources("Questionnaire").search(_id=request.match_info["id"]).get()
     )
-    env = await parameter_to_env(client, request["resource"])
+    body = await request.json()
+    env = await parameter_to_env(client, body)
     env["Questionnaire"] = questionnaire
-    populated_resource = await populate(client, questionnaire, env)
+    populated_resource = await populate(client, questionnaire, env, sdc_api=is_sdc_api(body))
 
     return web.json_response(populated_resource)
 

--- a/app/sdc/populate.py
+++ b/app/sdc/populate.py
@@ -59,6 +59,16 @@ async def populate(client, fhir_questionnaire, env):
     for item in fhir_questionnaire["item"]:
         root["item"].extend(await _handle_item(client, item, env, {}))
 
+    if env.get("useSDCAPI", False):
+        return {
+            "resourceType": "Parameters",
+            "parameter": [
+                {
+                    "name": "response",
+                    "resource": root
+                }
+            ]
+        }
     return root
 
 

--- a/app/sdc/populate.py
+++ b/app/sdc/populate.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 
 
 async def populate(client, fhir_questionnaire, env):
+    keys = env.keys()
+    for key in list(keys):
+        value = env[key]
+        if isinstance(value, dict) and value.get("resourceType") is None and value.get("reference") is not None:
+            env[key] = await client.reference(reference=value["reference"]).to_resource()
+
     exts = fhir_questionnaire.get("extension", [])
     launch_context = get_launch_context(exts)
     if launch_context:

--- a/app/sdc/populate.py
+++ b/app/sdc/populate.py
@@ -21,7 +21,7 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
-async def populate(client, fhir_questionnaire, env):
+async def populate(client, fhir_questionnaire, env, *, sdc_api: bool = False):
     exts = fhir_questionnaire.get("extension", [])
     launch_context = get_launch_context(exts)
     if launch_context:
@@ -53,7 +53,7 @@ async def populate(client, fhir_questionnaire, env):
     for item in fhir_questionnaire["item"]:
         root["item"].extend(await _handle_item(client, item, env, {}))
 
-    if env.get("useSDCAPI", False):
+    if sdc_api:
         return {"resourceType": "Parameters", "parameter": [{"name": "response", "resource": root}]}
     return root
 

--- a/app/sdc/populate.py
+++ b/app/sdc/populate.py
@@ -22,12 +22,6 @@ logger = logging.getLogger(__name__)
 
 
 async def populate(client, fhir_questionnaire, env):
-    keys = env.keys()
-    for key in list(keys):
-        value = env[key]
-        if isinstance(value, dict) and value.get("resourceType") is None and value.get("reference") is not None:
-            env[key] = await client.reference(reference=value["reference"]).to_resource()
-
     exts = fhir_questionnaire.get("extension", [])
     launch_context = get_launch_context(exts)
     if launch_context:
@@ -60,15 +54,7 @@ async def populate(client, fhir_questionnaire, env):
         root["item"].extend(await _handle_item(client, item, env, {}))
 
     if env.get("useSDCAPI", False):
-        return {
-            "resourceType": "Parameters",
-            "parameter": [
-                {
-                    "name": "response",
-                    "resource": root
-                }
-            ]
-        }
+        return {"resourceType": "Parameters", "parameter": [{"name": "response", "resource": root}]}
     return root
 
 

--- a/app/sdc/utils.py
+++ b/app/sdc/utils.py
@@ -160,6 +160,7 @@ def parameter_to_env(resource, is_fhir: bool = True):
             c = [p for p in param["part"] if p["name"] == "content"][0]
             get = [k for k in c.keys() if k != "name"][0]
             env[n] = c[get]
+            env["useSDCAPI"] = True
         elif "resource" in param:
             env[param["name"]] = param["resource"]
         else:

--- a/app/sdc/utils.py
+++ b/app/sdc/utils.py
@@ -156,9 +156,9 @@ def parameter_to_env(resource, is_fhir: bool = True):
     env = {}
     for param in resource["parameter"]:
         if param["name"] == "context":
-            n = [p for p in param['part'] if p['name'] == 'name'][0]['valueString']
-            c = [p for p in param['part'] if p['name'] == 'content'][0]
-            get = [k for k in c.keys() if k != 'name'][0]
+            n = [p for p in param["part"] if p["name"] == "name"][0]["valueString"]
+            c = [p for p in param["part"] if p["name"] == "content"][0]
+            get = [k for k in c.keys() if k != "name"][0]
             env[n] = c[get]
         elif "resource" in param:
             env[param["name"]] = param["resource"]

--- a/app/sdc/utils.py
+++ b/app/sdc/utils.py
@@ -155,7 +155,12 @@ def prepare_assemble_variables(item):
 def parameter_to_env(resource, is_fhir: bool = True):
     env = {}
     for param in resource["parameter"]:
-        if "resource" in param:
+        if param["name"] == "context":
+            n = [p for p in param['part'] if p['name'] == 'name'][0]['valueString']
+            c = [p for p in param['part'] if p['name'] == 'content'][0]
+            get = [k for k in c.keys() if k != 'name'][0]
+            env[n] = c[get]
+        elif "resource" in param:
             env[param["name"]] = param["resource"]
         else:
             value = parse_parameter_value(param, is_fhir)

--- a/app/sdc/utils.py
+++ b/app/sdc/utils.py
@@ -19,8 +19,7 @@ from .exception import ConstraintCheckOperationOutcome
 
 r4 = models["r4"]
 
-# TODO: it's outside from spec, if it's only for data fetching,
-# TODO: better to use dataEndpoint and it should be handled in `parameter_to_env` function
+# NOTE: it's outside from spec
 EXTERNAL_FHIR_BASE_URL_PARAM_KEY = "externalFhirBaseUrl"
 
 

--- a/app/sdc/utils.py
+++ b/app/sdc/utils.py
@@ -161,17 +161,19 @@ def prepare_assemble_variables(item):
 async def parameter_to_env(
     client: AsyncFHIRClient, resource, is_fhir: bool = True
 ) -> dict[str, Any]:
-    # TODO: add support resolving resources through local `data` or `dataEndpoint`
-    # TODO: according to spec https://build.fhir.org/ig/HL7/sdc/en/StructureDefinition-parameters-questionnaire-populate-in.html
+    # TODO: add support for repeating values (with same name)
     env: dict[str, Any] = {}
     for param in resource["parameter"]:
         if param["name"] == "context":
             parts = param["part"]
             name = next(p for p in parts if p["name"] == "name")["valueString"]
             value = next(p for p in parts if p["name"] == "content")
-            env[name] = await client.reference(
-                reference=value["valueReference"]["reference"]
-            ).to_resource()
+            if "resource" in value:
+                env[name] = value["resource"]
+            else:
+                env[name] = await client.reference(
+                    reference=value["valueReference"]["reference"]
+                ).to_resource()
             env["useSDCAPI"] = True
         elif "resource" in param:
             env[param["name"]] = param["resource"]

--- a/app/sdc/utils.py
+++ b/app/sdc/utils.py
@@ -157,6 +157,13 @@ def prepare_assemble_variables(item):
     return variables
 
 
+def is_sdc_api(parameters: dict | None) -> bool:
+    """True when Parameters use SDC `$populate` input shape (`context` and/or `subject`)."""
+    if not parameters or parameters.get("resourceType") != "Parameters":
+        return False
+    return any(p.get("name") in ("context", "subject") for p in parameters.get("parameter", []))
+
+
 async def parameter_to_env(
     client: AsyncFHIRClient, resource, is_fhir: bool = True
 ) -> dict[str, Any]:
@@ -173,7 +180,6 @@ async def parameter_to_env(
                 env[name] = await client.reference(
                     reference=value["valueReference"]["reference"]
                 ).to_resource()
-            env["useSDCAPI"] = True
         elif "resource" in param:
             env[param["name"]] = param["resource"]
         else:
@@ -183,7 +189,6 @@ async def parameter_to_env(
                     env[param["name"]] = await client.reference(
                         reference=value["reference"]
                     ).to_resource()
-                    env["useSDCAPI"] = True
                 else:
                     env[param["name"]] = value
     # Mapping parameters to fhir resource names

--- a/app/sdc/utils.py
+++ b/app/sdc/utils.py
@@ -1,7 +1,9 @@
 import copy
+from typing import Any
 from urllib.parse import quote
 
 from fhirpathpy.models import models
+from fhirpy import AsyncFHIRClient
 from fhirpy.base.exceptions import OperationOutcome
 from fhirpy.base.utils import get_by_path
 from fpml import resolve_template
@@ -152,14 +154,20 @@ def prepare_assemble_variables(item):
     return variables
 
 
-def parameter_to_env(resource, is_fhir: bool = True):
-    env = {}
+async def parameter_to_env(
+    client: AsyncFHIRClient, resource, is_fhir: bool = True
+) -> dict[str, Any]:
+    # TODO: add support resolving resources through local `data` or `dataEndpoint`
+    # TODO: according to spec https://build.fhir.org/ig/HL7/sdc/en/StructureDefinition-parameters-questionnaire-populate-in.html
+    env: dict[str, Any] = {}
     for param in resource["parameter"]:
         if param["name"] == "context":
-            n = [p for p in param["part"] if p["name"] == "name"][0]["valueString"]
-            c = [p for p in param["part"] if p["name"] == "content"][0]
-            get = [k for k in c.keys() if k != "name"][0]
-            env[n] = c[get]
+            parts = param["part"]
+            name = next(p for p in parts if p["name"] == "name")["valueString"]
+            value = next(p for p in parts if p["name"] == "content")
+            env[name] = await client.reference(
+                reference=value["valueReference"]["reference"]
+            ).to_resource()
             env["useSDCAPI"] = True
         elif "resource" in param:
             env[param["name"]] = param["resource"]

--- a/app/sdc/utils.py
+++ b/app/sdc/utils.py
@@ -19,6 +19,10 @@ from .exception import ConstraintCheckOperationOutcome
 
 r4 = models["r4"]
 
+# TODO: it's outside from spec, if it's only for data fetching,
+# TODO: better to use dataEndpoint and it should be handled in `parameter_to_env` function
+EXTERNAL_FHIR_BASE_URL_PARAM_KEY = "externalFhirBaseUrl"
+
 
 def get_type(item, data):
     type = item["type"]
@@ -172,9 +176,15 @@ async def parameter_to_env(
         elif "resource" in param:
             env[param["name"]] = param["resource"]
         else:
-            value = parse_parameter_value(param, is_fhir)
+            value, kind = parse_parameter_value(param, is_fhir)
             if value:
-                env[param["name"]] = value
+                if param["name"] == "subject" and kind == "Reference":
+                    env[param["name"]] = await client.reference(
+                        reference=value["reference"]
+                    ).to_resource()
+                    env["useSDCAPI"] = True
+                else:
+                    env[param["name"]] = value
     # Mapping parameters to fhir resource names
     questionnaire = env.get("questionnaire")
     if questionnaire:
@@ -185,14 +195,27 @@ async def parameter_to_env(
     return env
 
 
-def parse_parameter_value(parameter, is_fhir: bool):
+def parse_parameter_value(parameter, is_fhir: bool) -> tuple[Any, str]:
     if is_fhir:
         _name_key, value_key = parameter.keys()
-        return parameter[value_key]
-    else:
-        value = parameter["value"]
-        polimorphic_key = first(value.keys())
-        return value[polimorphic_key] if polimorphic_key else None
+        return parameter[value_key], value_key.removeprefix("value")
+
+    value = parameter["value"]
+    polimorphic_key = first(value.keys())
+    return value[polimorphic_key] if polimorphic_key else None, polimorphic_key
+
+
+def get_external_fhir_base_url_from_resource(resource: dict | None, is_fhir: bool):
+    if not resource or resource.get("resourceType") != "Parameters":
+        return None
+    for param in resource.get("parameter", []):
+        if param.get("name") != EXTERNAL_FHIR_BASE_URL_PARAM_KEY:
+            continue
+        if "resource" in param:
+            continue
+        value, _key = parse_parameter_value(param, is_fhir)
+        return value or None
+    return None
 
 
 async def load_source_queries(client, fce_questionnaire, env):

--- a/tests/sdc/test_populate.py
+++ b/tests/sdc/test_populate.py
@@ -1948,3 +1948,77 @@ async def test_named_item_population_context_parent_child_repeating_populate(fhi
             },
         ],
     }
+
+@pytest.mark.asyncio
+async def test_initial_expression_populate_sdc_api(fhir_client, safe_db):
+    q = await create_questionnaire(
+        fhir_client,
+        {
+            "status": "active",
+            "extension": [
+                make_launch_context_ext("LaunchPatient", "Patient"),
+            ],
+            "item": [
+                {
+                    "type": "string",
+                    "linkId": "patientGiven",
+                    "extension": [make_initial_expression_ext("%LaunchPatient.name.given")],
+                },
+            ],
+        },
+    )
+
+    launch_patient = fhir_client.resource('Patient',
+        name= [{"given": ["John"]}]
+    )
+    await launch_patient.save()
+
+    patient_id = launch_patient["id"]
+
+    patient_ref = {
+        "reference": f"Patient/{patient_id}",
+        "display": "Dow, John"
+    }
+
+    p = await fhir_client.execute("Questionnaire/$populate", data={
+        "resourceType": "Parameters",
+        "parameter": [
+            {
+                "name": "questionnaire",
+                "resource": q
+            },
+            {
+                "name": "context",
+                "part": [
+                    {
+                        "name": "name",
+                        "valueString": "LaunchPatient"
+                    },
+                    {
+                        "name": "content",
+                        "valueReference": patient_ref
+                    }
+                ]
+            }
+        ]
+    })
+
+    assert p == {
+        "resourceType": "Parameters",
+        "parameter": [
+            {
+                "name": "response",
+                "resource": {
+                    "resourceType": "QuestionnaireResponse",
+                    "status": "in-progress",
+                    "questionnaire": q.id,
+                    "item": [
+                        {
+                            "linkId": "patientGiven",
+                            "answer": [{"valueString": "John"}],
+                        }
+                    ],
+                }
+            }
+        ]
+    }

--- a/tests/sdc/test_populate.py
+++ b/tests/sdc/test_populate.py
@@ -1949,6 +1949,7 @@ async def test_named_item_population_context_parent_child_repeating_populate(fhi
         ],
     }
 
+
 @pytest.mark.asyncio
 async def test_initial_expression_populate_sdc_api(fhir_client, safe_db):
     q = await create_questionnaire(
@@ -1957,6 +1958,7 @@ async def test_initial_expression_populate_sdc_api(fhir_client, safe_db):
             "status": "active",
             "extension": [
                 make_launch_context_ext("LaunchPatient", "Patient"),
+                make_launch_context_ext("subject", "Patient"),
             ],
             "item": [
                 {
@@ -1964,12 +1966,18 @@ async def test_initial_expression_populate_sdc_api(fhir_client, safe_db):
                     "linkId": "patientGiven",
                     "extension": [make_initial_expression_ext("%LaunchPatient.name.given")],
                 },
+                {
+                    "type": "string",
+                    "linkId": "patientId",
+                    "extension": [make_initial_expression_ext("%subject.id")],
+                },
             ],
         },
     )
 
-    launch_patient = fhir_client.resource('Patient',
-        name= [{"given": ["John"]}]
+    launch_patient = fhir_client.resource(
+        "Patient",
+        name=[{"given": ["John"]}],
     )
     await launch_patient.save()
 
@@ -1977,31 +1985,26 @@ async def test_initial_expression_populate_sdc_api(fhir_client, safe_db):
 
     patient_ref = {
         "reference": f"Patient/{patient_id}",
-        "display": "Dow, John"
+        "display": "Dow, John",
     }
 
-    p = await fhir_client.execute("Questionnaire/$populate", data={
-        "resourceType": "Parameters",
-        "parameter": [
-            {
-                "name": "questionnaire",
-                "resource": q
-            },
-            {
-                "name": "context",
-                "part": [
-                    {
-                        "name": "name",
-                        "valueString": "LaunchPatient"
-                    },
-                    {
-                        "name": "content",
-                        "valueReference": patient_ref
-                    }
-                ]
-            }
-        ]
-    })
+    p = await fhir_client.execute(
+        "Questionnaire/$populate",
+        data={
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "questionnaire", "resource": q},
+                {
+                    "name": "context",
+                    "part": [
+                        {"name": "name", "valueString": "LaunchPatient"},
+                        {"name": "content", "valueReference": patient_ref},
+                    ],
+                },
+                {"name": "subject", "valueReference": patient_ref},
+            ],
+        },
+    )
 
     assert p == {
         "resourceType": "Parameters",
@@ -2016,9 +2019,13 @@ async def test_initial_expression_populate_sdc_api(fhir_client, safe_db):
                         {
                             "linkId": "patientGiven",
                             "answer": [{"valueString": "John"}],
-                        }
+                        },
+                        {
+                            "linkId": "patientId",
+                            "answer": [{"valueString": patient_id}],
+                        },
                     ],
-                }
-            }
-        ]
+                },
+            },
+        ],
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -272,3 +272,41 @@ def test_parameter_to_env_skips_empty_launch_param():
     assert "launch-patientId" not in env
     assert env["Questionnaire"] == questionnaire
     assert env["QuestionnaireResponse"] == questionnaire_response
+
+def test_sdc_api_params():
+    questionnaire = {
+        "resourceType": "Questionnaire",
+        "id": "q-1",
+        "status": "active",
+    }
+
+    patient_ref = {
+        "reference": "Patient/3bb82b9c-70b4-407e-ab0c-471b59b8daca",
+        "display": "Dow, John"
+    }
+
+    parameters = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {
+                "name": "questionnaire",
+                "resource": questionnaire
+            },
+            {
+                "name": "context",
+                "part": [
+                    {
+                        "name": "name",
+                        "valueString": "Patient"
+                    },
+                    {
+                        "name": "content",
+                        "valueReference": patient_ref
+                    }
+                ]
+            }
+        ]
+    }
+    env = parameter_to_env(parameters, is_fhir=False)
+    assert env["useSDCAPI"] is True
+    assert env["Patient"] == patient_ref

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -374,3 +374,39 @@ async def test_sdc_api_params(fhir_client, safe_db):
     assert resolved["id"] == patient.id
     assert resolved["name"][0]["family"] == "ApiParams"
     assert resolved["name"][0]["given"] == ["SdcIntegration"]
+
+
+@pytest.mark.asyncio
+async def test_sdc_api_params_with_resource(fhir_client, safe_db):
+    patient = {
+        "resourceType": "Patient",
+        "name": [{"family": "ApiParams", "given": ["SdcIntegration"]}],
+    }
+
+    questionnaire = {
+        "resourceType": "Questionnaire",
+        "id": "q-sdc-api-params",
+        "status": "active",
+    }
+
+    parameters = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "questionnaire", "resource": questionnaire},
+            {
+                "name": "context",
+                "part": [
+                    {"name": "name", "valueString": "Patient"},
+                    {"name": "content", "resource": patient},
+                ],
+            },
+        ],
+    }
+
+    env = await parameter_to_env(fhir_client, parameters, is_fhir=False)
+
+    assert env["useSDCAPI"] is True
+    resolved = env["Patient"]
+    assert resolved["resourceType"] == "Patient"
+    assert resolved["name"][0]["family"] == "ApiParams"
+    assert resolved["name"][0]["given"] == ["SdcIntegration"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from app.sdc.utils import (
@@ -218,7 +220,8 @@ def test_fpml():
         ),
     ],
 )
-def test_parameter_to_env_handles_parameters_correctly(is_fhir, launch_param):
+async def test_parameter_to_env_handles_parameters_correctly(is_fhir, launch_param):
+    client = MagicMock()
     questionnaire = {
         "resourceType": "Questionnaire",
         "id": "q-1",
@@ -238,7 +241,7 @@ def test_parameter_to_env_handles_parameters_correctly(is_fhir, launch_param):
         ],
     }
 
-    env = parameter_to_env(parameters, is_fhir)
+    env = await parameter_to_env(client, parameters, is_fhir)
 
     assert env["questionnaire"] == questionnaire
     assert env["questionnaire_response"] == questionnaire_response
@@ -247,7 +250,8 @@ def test_parameter_to_env_handles_parameters_correctly(is_fhir, launch_param):
     assert env["QuestionnaireResponse"] == questionnaire_response
 
 
-def test_parameter_to_env_skips_empty_launch_param():
+async def test_parameter_to_env_skips_empty_launch_param():
+    client = MagicMock()
     questionnaire = {
         "resourceType": "Questionnaire",
         "id": "q-1",
@@ -267,13 +271,58 @@ def test_parameter_to_env_skips_empty_launch_param():
         ],
     }
 
-    env = parameter_to_env(parameters, is_fhir=False)
+    env = await parameter_to_env(client, parameters, is_fhir=False)
 
     assert "launch-patientId" not in env
     assert env["Questionnaire"] == questionnaire
     assert env["QuestionnaireResponse"] == questionnaire_response
 
-def test_sdc_api_params():
+
+@pytest.mark.asyncio
+async def test_parameter_to_env_resolves_context_reference(fhir_client, safe_db):
+    obs = fhir_client.resource(
+        "Observation",
+        status="final",
+        code={"text": "parameter-to-env-integration"},
+    )
+    await obs.save()
+
+    parameters = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {
+                "name": "context",
+                "part": [
+                    {"name": "name", "valueString": "Observation"},
+                    {
+                        "name": "content",
+                        "valueReference": {"reference": f"Observation/{obs.id}"},
+                    },
+                ],
+            },
+        ],
+    }
+
+    env = await parameter_to_env(fhir_client, parameters, is_fhir=True)
+
+    assert env["useSDCAPI"] is True
+    resolved = env["Observation"]
+    assert resolved["resourceType"] == "Observation"
+    assert resolved["id"] == obs.id
+    assert resolved["status"] == "final"
+    assert resolved["code"]["text"] == "parameter-to-env-integration"
+
+
+async def test_sdc_api_params():
+    resolved_patient = {
+        "resourceType": "Patient",
+        "id": "3bb82b9c-70b4-407e-ab0c-471b59b8daca",
+    }
+    ref_proxy = MagicMock()
+    ref_proxy.to_resource = AsyncMock(return_value=resolved_patient)
+    client = MagicMock()
+    client.reference = MagicMock(return_value=ref_proxy)
+
     questionnaire = {
         "resourceType": "Questionnaire",
         "id": "q-1",
@@ -282,31 +331,23 @@ def test_sdc_api_params():
 
     patient_ref = {
         "reference": "Patient/3bb82b9c-70b4-407e-ab0c-471b59b8daca",
-        "display": "Dow, John"
+        "display": "Dow, John",
     }
 
     parameters = {
         "resourceType": "Parameters",
         "parameter": [
-            {
-                "name": "questionnaire",
-                "resource": questionnaire
-            },
+            {"name": "questionnaire", "resource": questionnaire},
             {
                 "name": "context",
                 "part": [
-                    {
-                        "name": "name",
-                        "valueString": "Patient"
-                    },
-                    {
-                        "name": "content",
-                        "valueReference": patient_ref
-                    }
-                ]
-            }
-        ]
+                    {"name": "name", "valueString": "Patient"},
+                    {"name": "content", "valueReference": patient_ref},
+                ],
+            },
+        ],
     }
-    env = parameter_to_env(parameters, is_fhir=False)
+    env = await parameter_to_env(client, parameters, is_fhir=False)
     assert env["useSDCAPI"] is True
-    assert env["Patient"] == patient_ref
+    assert env["Patient"] == resolved_patient
+    client.reference.assert_called_once_with(reference=patient_ref["reference"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.sdc.utils import (
+    is_sdc_api,
     parameter_to_env,
     prepare_bundle,
     prepare_link_ids,
@@ -211,6 +212,62 @@ def test_fpml():
 
 
 @pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (None, False),
+        ({}, False),
+        ({"resourceType": "Patient", "id": "x"}, False),
+        ({"resourceType": "Parameters", "parameter": []}, False),
+        (
+            {
+                "resourceType": "Parameters",
+                "parameter": [{"name": "questionnaire", "resource": {}}],
+            },
+            False,
+        ),
+        (
+            {
+                "resourceType": "Parameters",
+                "parameter": [
+                    {"name": "Questionnaire", "resource": {}},
+                    {"name": "LaunchPatient", "resource": {"resourceType": "Patient"}},
+                ],
+            },
+            False,
+        ),
+        (
+            {
+                "resourceType": "Parameters",
+                "parameter": [
+                    {"name": "subject", "valueReference": {"reference": "Patient/1"}},
+                ],
+            },
+            True,
+        ),
+        (
+            {
+                "resourceType": "Parameters",
+                "parameter": [{"name": "context", "part": []}],
+            },
+            True,
+        ),
+        (
+            {
+                "resourceType": "Parameters",
+                "parameter": [
+                    {"name": "context", "part": []},
+                    {"name": "subject", "valueReference": {"reference": "Patient/1"}},
+                ],
+            },
+            True,
+        ),
+    ],
+)
+def test_is_sdc_api(payload, expected):
+    assert is_sdc_api(payload) is expected
+
+
+@pytest.mark.parametrize(
     "is_fhir,launch_param",
     [
         (True, {"name": "launch-patientId", "valueString": "patient-123"}),
@@ -305,7 +362,7 @@ async def test_parameter_to_env_resolves_context_reference(fhir_client, safe_db)
 
     env = await parameter_to_env(fhir_client, parameters, is_fhir=True)
 
-    assert env["useSDCAPI"] is True
+    assert is_sdc_api(parameters) is True
     resolved = env["Observation"]
     assert resolved["resourceType"] == "Observation"
     assert resolved["id"] == obs.id
@@ -328,7 +385,7 @@ async def test_parameter_to_env_resolves_subject_reference(fhir_client, safe_db)
 
     env = await parameter_to_env(fhir_client, parameters, is_fhir=True)
 
-    assert env["useSDCAPI"] is True
+    assert is_sdc_api(parameters) is True
     assert env["subject"]["resourceType"] == "Patient"
     assert env["subject"]["id"] == patient.id
 
@@ -349,7 +406,7 @@ async def test_parameter_to_env_does_not_resolve_non_subject_reference(fhir_clie
 
     env = await parameter_to_env(fhir_client, parameters, is_fhir=True)
 
-    assert "useSDCAPI" not in env
+    assert is_sdc_api(parameters) is False
     assert env["PatientRef"]["display"] == "Integration Patient"
     assert env["PatientRef"]["reference"] == f"Patient/{patient.id}"
 
@@ -389,7 +446,7 @@ async def test_sdc_api_params(fhir_client, safe_db):
 
     env = await parameter_to_env(fhir_client, parameters, is_fhir=False)
 
-    assert env["useSDCAPI"] is True
+    assert is_sdc_api(parameters) is True
     resolved = env["Patient"]
     assert resolved["resourceType"] == "Patient"
     assert resolved["id"] == patient.id
@@ -426,7 +483,7 @@ async def test_sdc_api_params_with_resource(fhir_client, safe_db):
 
     env = await parameter_to_env(fhir_client, parameters, is_fhir=False)
 
-    assert env["useSDCAPI"] is True
+    assert is_sdc_api(parameters) is True
     resolved = env["Patient"]
     assert resolved["resourceType"] == "Patient"
     assert resolved["name"][0]["family"] == "ApiParams"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -313,6 +313,26 @@ async def test_parameter_to_env_resolves_context_reference(fhir_client, safe_db)
     assert resolved["code"]["text"] == "parameter-to-env-integration"
 
 
+@pytest.mark.asyncio
+async def test_parameter_to_env_subject_resolves(fhir_client, safe_db):
+    patient = fhir_client.resource("Patient")
+    await patient.save()
+    patient_ref = {"reference": f"Patient/{patient.id}"}
+
+    parameters = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "subject", "valueReference": patient_ref},
+        ],
+    }
+
+    env = await parameter_to_env(fhir_client, parameters, is_fhir=True)
+
+    assert env["useSDCAPI"] is True
+    assert env["subject"]["resourceType"] == "Patient"
+    assert env["subject"]["id"] == patient.id
+
+
 async def test_sdc_api_params():
     resolved_patient = {
         "resourceType": "Patient",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -333,25 +333,23 @@ async def test_parameter_to_env_subject_resolves(fhir_client, safe_db):
     assert env["subject"]["id"] == patient.id
 
 
-async def test_sdc_api_params():
-    resolved_patient = {
-        "resourceType": "Patient",
-        "id": "3bb82b9c-70b4-407e-ab0c-471b59b8daca",
-    }
-    ref_proxy = MagicMock()
-    ref_proxy.to_resource = AsyncMock(return_value=resolved_patient)
-    client = MagicMock()
-    client.reference = MagicMock(return_value=ref_proxy)
+@pytest.mark.asyncio
+async def test_sdc_api_params(fhir_client, safe_db):
+    patient = fhir_client.resource(
+        "Patient",
+        name=[{"family": "ApiParams", "given": ["SdcIntegration"]}],
+    )
+    await patient.save()
 
     questionnaire = {
         "resourceType": "Questionnaire",
-        "id": "q-1",
+        "id": "q-sdc-api-params",
         "status": "active",
     }
 
     patient_ref = {
-        "reference": "Patient/3bb82b9c-70b4-407e-ab0c-471b59b8daca",
-        "display": "Dow, John",
+        "reference": f"Patient/{patient.id}",
+        "display": "Integration Patient",
     }
 
     parameters = {
@@ -367,7 +365,12 @@ async def test_sdc_api_params():
             },
         ],
     }
-    env = await parameter_to_env(client, parameters, is_fhir=False)
+
+    env = await parameter_to_env(fhir_client, parameters, is_fhir=False)
+
     assert env["useSDCAPI"] is True
-    assert env["Patient"] == resolved_patient
-    client.reference.assert_called_once_with(reference=patient_ref["reference"])
+    resolved = env["Patient"]
+    assert resolved["resourceType"] == "Patient"
+    assert resolved["id"] == patient.id
+    assert resolved["name"][0]["family"] == "ApiParams"
+    assert resolved["name"][0]["given"] == ["SdcIntegration"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -314,7 +314,7 @@ async def test_parameter_to_env_resolves_context_reference(fhir_client, safe_db)
 
 
 @pytest.mark.asyncio
-async def test_parameter_to_env_subject_resolves(fhir_client, safe_db):
+async def test_parameter_to_env_resolves_subject_reference(fhir_client, safe_db):
     patient = fhir_client.resource("Patient")
     await patient.save()
     patient_ref = {"reference": f"Patient/{patient.id}"}
@@ -331,6 +331,27 @@ async def test_parameter_to_env_subject_resolves(fhir_client, safe_db):
     assert env["useSDCAPI"] is True
     assert env["subject"]["resourceType"] == "Patient"
     assert env["subject"]["id"] == patient.id
+
+
+@pytest.mark.asyncio
+async def test_parameter_to_env_does_not_resolve_non_subject_reference(fhir_client, safe_db):
+    # This test for backward compatibility with non sdc api behavior
+    patient = fhir_client.resource("Patient")
+    await patient.save()
+    patient_ref = {"reference": f"Patient/{patient.id}", "display": "Integration Patient"}
+
+    parameters = {
+        "resourceType": "Parameters",
+        "parameter": [
+            {"name": "PatientRef", "valueReference": patient_ref},
+        ],
+    }
+
+    env = await parameter_to_env(fhir_client, parameters, is_fhir=True)
+
+    assert "useSDCAPI" not in env
+    assert env["PatientRef"]["display"] == "Integration Patient"
+    assert env["PatientRef"]["reference"] == f"Patient/{patient.id}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I improved #135 by making parameter_to_env async - it gives us the single entrypoint of resources fetching for all other operations (constraint check, populate, assemble, extract - where we still use context). 
I also added passing `resource` inside context.part.content according to spec https://build.fhir.org/ig/HL7/sdc/en/OperationDefinition-Questionnaire-populate.html

And original PR #135 introduced **regression** for existing behaviour, when **any** reference transformed into resource. But existing questionnaires might rely on pure reference (e.g. by referring to `display`). For them we should not automatically resolve. See test [here](https://github.com/beda-software/fhir-sdc/pull/136/changes#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33R337).